### PR TITLE
report-generator: Remove empty pages

### DIFF
--- a/report-generator/main.adoc
+++ b/report-generator/main.adoc
@@ -12,11 +12,7 @@ Test report
 :iconsdir: ./doc/icons/
 :sectnumlevels: 1
 
-include::include/prerequisites.adoc[]
-
 include::include/test-reports.adoc[]
-
-include::include/notes.adoc[]
 
 == About this documentation
 


### PR DESCRIPTION
Prerequisites and notes were blank pages.
