### PR TITLE
ansible-lint.conf: add configuration for ansible-lint

### DIFF
--- a/ansible-lint.conf
+++ b/ansible-lint.conf
@@ -1,0 +1,42 @@
+# Copyright (C) 2023, RTE (http://www.rte-france.com)
+# SPDX-License-Identifier: Apache-2.0
+#
+# This file handle the configuration of ansible-lint
+
+exclude_paths:
+  - ceph-ansible
+  - roles/systemd_networkd
+  - roles/corosync
+
+# ceph-ansible, systemd_networkd and corosync are submodules and seapath don't
+# have control of them.
+
+skip_list:
+  - yaml                   # yaml syntax warnings
+  - unnamed-task           # All tasks should be named
+  - role-name              # All role names should match "^[a-z_][a-z0-9_]*$"
+  - risky-file-permissions # All file creation must specify permissions
+  - no-handler             # "when: result.changed" should trigger a handler instead
+  - no-changed-when        # Commands should not change things if nothing needs doing
+  - no-tabs                # Most files should not contain tabs
+
+### Why skip these warnings :
+#
+# - yaml errors are mostly "line >80 chars" and comment formatting. A yaml auto
+# formatter could be run on the repository and would correct some problems.
+# Reducing the length size requires a lot of reformatting work and isn't a big
+# deal for now.
+#
+# - unnamed-task are all debugging task and thus not so important to name.
+#
+# - role-name doesn't seem too important to us.
+#
+# - risky-file-permissions concern a global cyber-security question : Specifying
+# permissions on files must be done on the overall SEAPATH project in order to
+# be effective. This is a much bigger task.
+#
+# - no-tabs is raised by a patch task. The patched tool should soon merge the
+# patch and this will not be required anymore.
+#
+# - no-handler and no-changed-when should not be skipped. The raised warnings
+# should be corrected as soon as possible for these two rules to run on the CI.

--- a/ansible-lint.sh
+++ b/ansible-lint.sh
@@ -46,13 +46,14 @@ initialization() {
 
 # Launch ansible-lint
 ansible_lint() {
+  cp ci/ansible-lint.conf ansible
   cd ansible
   INVENTORIES_DIR=/home/virtu/ansible/seapath_inventories
   CQFD_EXTRA_RUN_ARGS=" \
     -v $INVENTORIES_DIR:/etc/ansible/hosts \
     -v $WORK_DIR/ansible/ceph-ansible/roles:/etc/ansible/roles \
     " \
-  cqfd run ansible-lint -x yaml
+  cqfd run ansible-lint -c ansible-lint.conf
 }
 
 case "$1" in


### PR DESCRIPTION
ansible-lint.conf is copied in the downloaded ansible repository by the ansible-lint.sh script. It configures the way ansible-lint check the code :
- excludes some directories
- ignores some rules

Further explanation in the ansible-lint.conf file.

Signed-off-by: Erwann Roussy <erwann.roussy@savoirfairelinux.com>