### PR TITLE
Latency tests analyze integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__
+*.png
+.vscode/*
+*.pdf

--- a/report-generator/.cqfd/docker/Dockerfile
+++ b/report-generator/.cqfd/docker/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 	asciidoc \
 	bash \
 	locales \
+	python3-matplotlib \
 	ruby \
 	ruby-asciidoctor-pdf \
 	xmlstarlet \

--- a/report-generator/.cqfdrc
+++ b/report-generator/.cqfdrc
@@ -4,3 +4,7 @@ name='asciidoc-report'
 
 [build]
 command='./compile.sh -s -i /tmp/cukinia-res'
+flavors='build_latency'
+
+[build_latency]
+command='./compile_latency.sh /tmp/tests_results/'

--- a/report-generator/compile_latency.sh
+++ b/report-generator/compile_latency.sh
@@ -1,0 +1,72 @@
+#!/bin/bash -e
+
+
+
+LATENCY_ADOC_FILE=$(readlink -f "include/latency-test-reports.adoc")
+STATS_FILE="include/stats_results"
+
+
+if [ -f $LATENCY_ADOC_FILE ] ; then
+    rm $LATENCY_ADOC_FILE
+fi
+
+if [ -f $STATS_FILE ] ; then
+    rm $STATS_FILE
+fi
+
+if [ -z $1 ] ; then
+    echo "Fatal: test result directory not given"
+    echo "Hint: ./compile_latency.sh <TEST_RESULTS_DIR>"
+    exit 1
+fi
+
+# If a previous test was aborted, check if $STATS_FILE and $LATENCY_ADOC_FILE
+# exists, and deleting them if so
+
+generate_latency_results()
+{
+    # Generate graph and stats associated to a publisher and subscriber test
+    # Parameters: $1: publisher result file
+    # $2: subscriber result file
+
+    local PUB_DATA_FILE=$1
+    local SUB_DATA_FILE=$2
+    python3 timestamp_analysis/timestamp_analysis.py \
+    $PUB_DATA_FILE \
+    $SUB_DATA_FILE >> $STATS_FILE
+}
+
+
+add_latency_results()
+{
+    # Generate and add latency tests results to final report
+    # Parameter: $1: path to tests results directory
+    echo "==  Latency tests results ==" >> "$LATENCY_ADOC_FILE"
+    local TESTS_RESULTS_DIR=$1
+    local SUB_RESULTS_FILES_HYPERVISOR="${TESTS_RESULTS_DIR}sub*hypervisor*" # Getting all sub files results
+    local PUB_RESULT_FILE_HYPERVISOR="${TESTS_RESULTS_DIR}/pub_results_hypervisor_standalone" # Publisher file result
+
+    # Compute hypervisor subscriber tests results
+    for SUB_RESULT_FILE in $SUB_RESULTS_FILES_HYPERVISOR # For each sub result file
+    do
+        generate_latency_results $PUB_RESULT_FILE_HYPERVISOR $SUB_RESULT_FILE # Generate graph and stats associate to it
+        local SUB_MACHINE_NAME="$(echo $SUB_RESULT_FILE|cut -d'/' -f4|cut -d'_' -f4)" # Getting sub hypervisor machine name
+        # Output example: $SUB_RESULT_FILE = /tmp/tests_results/sub_results_hypervisor_virtu-ci1 --> $SUB_MACHINE_NAME = virtu-ci1
+
+        echo "=== $SUB_MACHINE_NAME" >> "$LATENCY_ADOC_FILE" # Subtitle for each subscriber
+        echo "image::./include/sub_"$SUB_MACHINE_NAME"_delay.png[]" >> "$LATENCY_ADOC_FILE" # Include delay graph
+        echo "image::./include/pub_standalone_interval_between.png[]" >> "$LATENCY_ADOC_FILE" # Include time between packets graph
+        echo " " >> "$LATENCY_ADOC_FILE"
+
+        sed -i 's/$/ +/' $STATS_FILE # Add '+' character at the end of each file sub stat line for making carriage return
+        cat $STATS_FILE >> "$LATENCY_ADOC_FILE" # Add sub stats data in report file
+        echo " " >> "$LATENCY_ADOC_FILE"
+        rm "$STATS_FILE"
+    done
+
+
+}
+
+add_latency_results $1
+asciidoctor-pdf main_latency.adoc
+rm $LATENCY_ADOC_FILE

--- a/report-generator/main.adoc
+++ b/report-generator/main.adoc
@@ -1,7 +1,6 @@
 // Copyright (C) 2022, Savoir-faire Linux (https://www.savoirfairelinux.com)
 // SPDX-License-Identifier: CC-BY-4.0
 
-:imagesdir: ./doc/images/
 :pdf-theme: themes/theme.yml
 :doctype: book
 

--- a/report-generator/main.adoc
+++ b/report-generator/main.adoc
@@ -31,4 +31,4 @@ If you prefer a PDF version of the documentation instead, use the following
 command (the dblatex package will need to be installed on your Linux
 distribution):
 
-  $ asciidoctor-pdf main.adoc
+  $ asciidoctor-pdf main_latency.adoc

--- a/report-generator/main_latency.adoc
+++ b/report-generator/main_latency.adoc
@@ -1,0 +1,34 @@
+// Copyright (C) 2022, Savoir-faire Linux (https://www.savoirfairelinux.com)
+// SPDX-License-Identifier: CC-BY-4.0
+
+:pdf-theme: themes/theme.yml
+:doctype: book
+
+Test report
+===========
+:toc:
+:icons:
+:iconsdir: ./doc/icons/
+:sectnumlevels: 1
+
+include::include/latency-test-reports.adoc[]
+
+== About this documentation
+
+This documentation uses the AsciiDoc documentation generator. It is a convenient
+format that allows using plain-text formatted writing that can later be
+converted to various output formats such as HTML and PDF.
+
+In order to generate an HTML version of this documentation, use the following
+command (the asciidoc package will need to be installed in your Linux
+distribution):
+
+  $ asciidoc main.adoc
+
+This will result in a README.html file being generated in the current directory.
+
+If you prefer a PDF version of the documentation instead, use the following
+command (the dblatex package will need to be installed on your Linux
+distribution):
+
+  $ asciidoctor-pdf main.adoc

--- a/report-generator/timestamp_analysis/post_processing_utils.py
+++ b/report-generator/timestamp_analysis/post_processing_utils.py
@@ -1,0 +1,48 @@
+# Copyright (C) 2023, RTE (http://www.rte-france.com)
+# SPDX-License-Identifier: Apache-2.0
+#
+## Data class for SV timestamps
+import argparse
+import statistics
+from sys import argv
+
+
+class SV:
+    pub_bts=None
+    pub_ats=None
+    pub_hwts=None
+    sub_ts=None
+
+    def __init__(self, pub_hwts, pub_bts=None, pub_ats=None):
+        self.pub_hwts = pub_hwts
+        if pub_bts:
+            self.pub_bts=pub_bts
+        if pub_ats:
+            self.pub_ats=pub_ats
+
+    def __str__(self):
+        return f'(pub_bts={self.pub_bts}, pub_hwts={self.pub_hwts}, pub_ats={self.pub_ats}, sub_ts={self.sub_ts})'
+
+
+def results_reader(file_name):
+    with open(file_name) as f:
+        for l in f:
+            data = l.strip("\n").split(" ")
+            yield list([data[0]] + [int(data[2*i+1])*1000000000 + int(data[2*(i+1)]) for i in range(int((len(data)-1)/2))])
+
+
+## Output a series based on a list of data
+def hist(data):
+    dataset = set(data)
+    hist_x = sorted(list(dataset))
+    hist_y = [data.count(k) for k in hist_x]
+    return hist_x, hist_y
+
+## TS in format hh:mm:ss.us (first tcpdump string) changed to time integer
+def ts_as_int(ts):
+    split_ts = ts.split(":")
+    assert len(split_ts) == 3, "Error expected time format hh:mm:ss.us"
+    split_sec = split_ts[2].split(".")
+    assert len(split_sec) == 2, "Error expected time format hh:mm:ss.us"
+
+    return int(split_sec[1]) + int(split_sec[0])*1000000 + int(split_ts[1]) * 60 * 1000000 + int(split_ts[0]) * 3600 * 1000000

--- a/report-generator/timestamp_analysis/timestamp_analysis.py
+++ b/report-generator/timestamp_analysis/timestamp_analysis.py
@@ -1,0 +1,124 @@
+# Copyright (C) 2023, RTE (http://www.rte-france.com)
+# SPDX-License-Identifier: Apache-2.0
+
+# This script analyzes timestamp of subscriber and publisher tests results,
+# and generates graph and stats from it.
+import os
+import matplotlib.pyplot as plt
+import statistics
+from post_processing_utils import *
+from sys import argv
+import argparse
+
+def main(argv):
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("pub_timestamp_file",
+                        help="file path to the output of SV publication stream timestamps, with lines in the format <packet id> <tv_sec> <tv_nsec>")
+    parser.add_argument("sub_timestamp_file",
+                        help="file path to the output of SV subscriber stream timestamps, with lines in the format <packet id> <tv_sec> <tv_nsec>")
+    args = parser.parse_args()
+
+
+    input_file_name_sub = os.path.expanduser(args.sub_timestamp_file)
+    input_file_name_pub = os.path.expanduser(args.pub_timestamp_file)
+    skip_first_n = 0
+    debug = False
+    extra_ts = False
+    pub_only = False
+
+    input_file_sub = os.path.expanduser(input_file_name_sub)
+    input_file_pub = os.path.expanduser(input_file_name_pub)
+
+
+    pub_data = {}
+    sv_data = {}
+    key_doublon = []
+    interval_between_pub_us = []
+    interval_hw2aclock = []
+    interval_bclock2hw = []
+    prev = None
+    for fields in results_reader(input_file_pub):
+        rid = fields[0]
+        hw_ts = fields[1]
+        if extra_ts:
+            clock_ts_before = fields[2]
+            clock_ts_after = fields[3]
+            interval_hw2aclock.append(clock_ts_after-hw_ts)
+            interval_bclock2hw.append(hw_ts-clock_ts_before)
+
+        if rid in pub_data:
+                print(f'pas de chance: id {rid} déjà présent')
+                key_doublon.append(rid)
+        else:
+            pub_data[rid]=hw_ts
+            sv_data[rid] = SV(hw_ts, clock_ts_before, clock_ts_after) if extra_ts else SV(hw_ts)
+
+        if prev:
+            interval_between_pub_us.append(round((hw_ts-prev)/1000))
+            if debug:
+                print("diff = " + str(hw_ts-prev))
+        prev = hw_ts
+
+    lat_pub_sub = []
+    index = 0
+    if not pub_only:
+        for fields in results_reader(input_file_sub):
+            rid = fields[0]
+            sub_ts = fields[1]
+            if rid not in key_doublon and rid in pub_data:
+                lat_pub_sub.append(sub_ts-pub_data[rid])
+                sv_data[rid].sub_ts = sub_ts
+            index+=1
+
+
+    interval_between_pub_us = interval_between_pub_us[skip_first_n:]
+    interval_hw2aclock = interval_hw2aclock[skip_first_n:]
+    interval_bclock2hw = interval_bclock2hw[skip_first_n:]
+    lat_pub_sub = lat_pub_sub[skip_first_n:]
+
+
+
+    x, y = hist([round(v/100) for v in lat_pub_sub])
+    plt.bar(x, y)
+    plt.xlabel('delay (x100 ns)')
+    plt.ylabel('occurences')
+    plt.title('pub(hw ts) -> sub (REALTIME) (1 stream)')
+    plt.yscale("log")
+
+    sub_name_parts = input_file_sub.split("_") # Spliting parts of subscriber data file name
+    sub_machine_name = sub_name_parts[-1].split(".")[0] # And getting subscriber machine name field
+
+
+    plt.savefig('include/sub_' + sub_machine_name + '_delay.png')
+    plt.close()
+
+    x, y = hist(interval_between_pub_us)
+    plt.bar(x, y)
+    plt.xlabel('time between packets (µs)')
+    plt.ylabel('occurences')
+    plt.title('trafgen SEAPATH (1 stream)')
+    plt.yscale("log")
+
+
+    pub_name_parts = input_file_pub.split("_") # Spliting parts of publisher data file name
+    pub_machine_name = pub_name_parts[-1].split(".")[0] # And getting publisher machine name field
+
+    plt.savefig('include/pub_' + pub_machine_name + '_interval_between.png')
+    plt.close()
+    print(f'Data: {len(lat_pub_sub)} frames\n'
+        f'    std dev pub-sub time: {statistics.pstdev(lat_pub_sub)} ns\n'
+        f'    median: {statistics.median(lat_pub_sub)} ns\n'
+        f'    mean: {statistics.mean(lat_pub_sub)} ns\n'
+        f'    min: {min(lat_pub_sub)} ns\n'
+        f'    max: {max(lat_pub_sub)} ns\n')
+
+    print(f'Data: {len(interval_between_pub_us)} frame pairs\n'
+        f'    std dev of frame-to-frame time: {statistics.pstdev(interval_between_pub_us)} µs\n'
+        f'    median: {statistics.median(interval_between_pub_us)} µs\n'
+        f'    mean: {statistics.mean(interval_between_pub_us)} µs\n'
+        f'    min: {min(interval_between_pub_us)} µs\n'
+        f'    max: {max(interval_between_pub_us)} µs\n')
+
+if __name__ == "__main__":
+    main(argv)


### PR DESCRIPTION
This PR adds a first integration of latency tests analysis: publisher/subscriber timestamp data analysis, statistics and graph generation, integration into final CI report.
To avoid any regression, on CI runtime, the latency test analyze is done in a separate script `compile_latency.sh`, different from main `compile.sh` script. The script can be executed by calling cqfd with `build_latency` flavor.

Following files are added:

- `compile_latency.sh`: main core script. Call python script for data analysis, statistics and graph generation. Finally, do the integration into final CI report.
- `report-generator/timestamp_analysis/post_processing_utils.py` and r`eport-generator/timestamp_analysis/timestamp_analysis.py`: analysis of timestamp data files, and generation of stats/graph belonging to them.