### PR TITLE
compile.sh: correct bug of last test not in report

### DIFF
--- a/report-generator/compile.sh
+++ b/report-generator/compile.sh
@@ -113,10 +113,11 @@ add_xml_to_adoc()
         echo "|Tests |Results" >> "$TEST_ADOC_FILE"
 
         local j=1
-        while read testcase ; do
+        local testcases=$(xmlstarlet sel -t -v "//testsuite[$i]/testcase/@name" "$xml")
+        echo "$testcases" | while read testcase ; do
             generate_row "$i" "$j" "$testcase" "$xml"
             let j++
-        done < <(xmlstarlet sel -t -v "//testsuite[$i]/testcase/@name" "$xml")
+        done
         echo "|===" >> "$TEST_ADOC_FILE"
         echo "{set:cellbgcolor!}" >> "$TEST_ADOC_FILE"
         echo "" >> "$TEST_ADOC_FILE"


### PR DESCRIPTION
It was noticed that the last test of each category wasn't displayed in the report. The problem was obviously a mistake in a loop that doesn't handle the last test.

In fact, the while loop reading test cases uses bash process substitution which is a bad idea. This method split lines on newline character and will thus not handle the last line if it is not terminated by a newline character.

Piping a variable directly in the while loop do this job and the last test appear.