### PR TITLE
launch: fetch inventories and rework the script to be more generic

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,20 @@ This repository hosts the code of the CI used on the Ansible repository.
 
 A user guide of the CI is available on [the Wiki page](https://wiki.lfenergy.org/display/SEAP/Continuous+integration+on+SEAPATH).
 
+## Prerequisites
+
+To use CI you must create the file /etc/seapath-ci.conf.This file is a shell
+source file where it can be defined variables used by the CI script.
+Only `PRIVATE_INVENTORIES_REPO_URL` is mandatory.
+- `PRIVATE_INVENTORIES_REPO_URL`: git URL to fetch inventories
+- `SEAPATH_BASE_REPO`: git main URL part. eg: github.com/seapath
+- `SEAPATH_SSH_BASE_REPO`: git main ssh URL part. eg: git@github.com:seapath
+- `REPO_PRIVATE_KEYFILE`: path of the SSH git private key used for pushing the report.
+- `ANSIBLE_INVENTORY`: Ansible inventory environment variable as described here: https://docs.ansible.com/ansible/latest/reference_appendices/config.html#envvar-ANSIBLE_INVENTORY
+- `SVTOOLS_TARBALL`: path to the svtools binary tarball
+- `TRAFGEN_TARBALL`: path to the tafgen binary tarball
+- `CA_DIR`: path to the directory containing syslog certificate
+
 ## Technical implementation
 
 The CI is called through a GitHub Action on Ansible debian-main branch. The script is contained in `.github/workflows/ci-debian.yml`

--- a/report-generator/compile_latency.sh
+++ b/report-generator/compile_latency.sh
@@ -44,7 +44,7 @@ add_latency_results()
     echo "==  Latency tests results ==" >> "$LATENCY_ADOC_FILE"
     local TESTS_RESULTS_DIR=$1
     local SUB_RESULTS_FILES_HYPERVISOR="${TESTS_RESULTS_DIR}sub*hypervisor*" # Getting all sub files results
-    local PUB_RESULT_FILE_HYPERVISOR="${TESTS_RESULTS_DIR}/pub_results_hypervisor_standalone" # Publisher file result
+    local PUB_RESULT_FILE_HYPERVISOR="${TESTS_RESULTS_DIR}/pub_results_hypervisor_*" # Publisher file result
 
     # Compute hypervisor subscriber tests results
     for SUB_RESULT_FILE in $SUB_RESULTS_FILES_HYPERVISOR # For each sub result file


### PR DESCRIPTION
To be used, launch.sh now requires the configuration file: /etc/seapath-ci.conf. This file is a shell source file where it can be defined variables used by the launch.sh script.
For the moment, only PRIVATE_INVENTORIES_REPO_URL is mandatory.

The following variables can be defined:
* PRIVATE_INVENTORIES_REPO_URL: git URL to fetch inventories
* SEAPATH_BASE_REPO: git main URL part. eg: github.com/seapath
* SEAPATH_SSH_BASE_REPO: git main ssh URL part. eg: git@github.com:seapath
* REPO_PRIVATE_KEYFILE: path of the SSH git private key used for pushing the report.
* ANSIBLE_INVENTORY: Ansible inventory environment variable as described here: https://docs.ansible.com/ansible/latest/reference_appendices/config.html#envvar-ANSIBLE_INVENTORY
* SVTOOLS_TARBALL: path to the svtools binary tarball
* TRAFGEN_TARBALL: path to the tafgen binary tarball