### PR TITLE
launch.sh: bug correction

### DIFF
--- a/launch.sh
+++ b/launch.sh
@@ -143,7 +143,7 @@ launch_system_tests() {
   fi
 
   # Display test results
-  if grep -q '<failure' $CUKINIA_TEST_DIR/* | grep -q -v '00080'; then
+  if grep '<failure' $CUKINIA_TEST_DIR/* | grep -q -v '00080'; then
     echo "Test fails, See test report in the section 'Upload test report'"
     exit 1
   else


### PR DESCRIPTION
piping a quiet grep in another grep always return true. Tests result were not parsed at all ... ouch.