### PR TITLE
parametrize INVENTORY_VM

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Only `PRIVATE_INVENTORIES_REPO_URL` is mandatory.
 - `SEAPATH_SSH_BASE_REPO`: git main ssh URL part. eg: git@github.com:seapath
 - `REPO_PRIVATE_KEYFILE`: path of the SSH git private key used for pushing the report.
 - `ANSIBLE_INVENTORY`: Ansible inventory environment variable as described here: https://docs.ansible.com/ansible/latest/reference_appendices/config.html#envvar-ANSIBLE_INVENTORY
+- `INVENTORY_VM`: path to the guest (vm.yml) inventory
 - `SVTOOLS_TARBALL`: path to the svtools binary tarball
 - `TRAFGEN_TARBALL`: path to the tafgen binary tarball
 - `CA_DIR`: path to the directory containing syslog certificate

--- a/launch.sh
+++ b/launch.sh
@@ -35,6 +35,9 @@ fi
 if [ -z "${REPO_PRIVATE_KEYFILE}" ] ; then
   REPO_PRIVATE_KEYFILE=inventories_private/ci_rsa
 fi
+if [ -z "${INVENTORY_VM}" ] ; then
+  INVENTORY_VM=inventories_private/vm.yml
+fi
 
 if [ -z "${ANSIBLE_INVENTORY}" ] ; then
   ANSIBLE_INVENTORY="inventories_private/seapath_cluster_ci.yml,inventories_private/seapath_standalone_rt.yml"
@@ -161,7 +164,7 @@ launch_vm_tests() {
   # Add VM inventory file
   # This file cannot be added at the beginnig of launch.sh cause it is used
   # only during thes step
-  ANSIBLE_INVENTORY="${ANSIBLE_INVENTORY},inventories_private/vm.yml"
+  ANSIBLE_INVENTORY="${ANSIBLE_INVENTORY},${INVENTORY_VM}"
   CQFD_EXTRA_RUN_ARGS="${CQFD_EXTRA_RUN_ARGS} -e ANSIBLE_INVENTORY=${ANSIBLE_INVENTORY} -v /etc/seapath-ci/vm_file:${WORK_DIR}/ansible/vm_images"
 
   cd ansible


### PR DESCRIPTION
This will allow having several CI (one specific for debian12 development for instance, keeping the working debian11 CI).
Right now the vm.yml parameter is hard coded so several CI would use the same VM parameters (name, ip address, macaddress...).
