### PR TITLE
launch.sh: correct vm tests grep.

### DIFF
--- a/launch.sh
+++ b/launch.sh
@@ -185,7 +185,7 @@ launch_vm_tests() {
   mv ${WORK_DIR}/ansible/cukinia_*.xml $INCLUDE_DIR # Test files
 
   # Display test results
-  if grep -q '<failure' $INCLUDE_DIR/*.xml; then
+  if grep '<failure' $INCLUDE_DIR/*.xml | grep -q -v '00080'; then
     echo "Test fails, See test report in the section 'Upload test report'"
     exit 1
   else


### PR DESCRIPTION
A grep command is launched after the VM tests to know if any test is failed. However, this command is launched over the directory containing all cukinia results, including the one from the hypervisors.

One of the possible test failure in debian CI is a kernel backtrace that we want to ignore (see 5a897ea).
The ignore was done properly in the hypervisor test part, but not in the vm test part.
This commit correct the grep command to ignore the backtrace test failure.