### PR TITLE
launch-yocto.sh: add ptp synchrnonization in deploy VMs

### DIFF
--- a/launch-yocto.sh
+++ b/launch-yocto.sh
@@ -115,7 +115,7 @@ deploy_vms() {
 
   cd ansible
   cqfd run ansible-playbook \
-  playbooks/deploy_vms_standalone.yaml
+  playbooks/ci_vms_standalone_ptp.yaml
   echo "test VMs deployed successfully"
 }
 


### PR DESCRIPTION
Use a new playbook in deploy VMs, which will call the previous one and also synchronize the system clock of each VMs to the ptp hardware clock.