### PR TITLE
Use test-report-pdf new version

### DIFF
--- a/launch.sh
+++ b/launch.sh
@@ -229,15 +229,16 @@ launch_latency_tests() {
 # Generate the test report and upload it
 generate_report() {
 
-  # Replace test-report-pdf themes with SEAPATH one
   cd "${WORK_DIR}/ci/test-report-pdf"
-  rm themes/sfl.png
-  mv ../seapath-themes/logo.png themes
-  mv ../seapath-themes/theme.yml themes/sfl-theme.yml
+  # Replace test-report-pdf default logo by SEAPATH one
+  mv ../seapath-themes/logo.png themes/sfl.png
+  sed -i 's/contact@savoirfairelinux/seapath@savoirfairelinux/g' test-report.adoc
+  # Change contact mailing list to seapath SFL mailing list
 
   # Generate test report
   cqfd -q init
-  if ! CQFD_EXTRA_RUN_ARGS="" cqfd -q run ./compile.py -s -m -i include \
+  if ! CQFD_EXTRA_RUN_ARGS="" cqfd -q run ./compile.py \
+      -m -i include -C SEAPATH -p \"SEAPATH Debian\" \
       -c include/ANSSI-BP28-Recommandations-M.csv \
       -c include/ANSSI-BP28-Recommandations-MI.csv \
       -c include/ANSSI-BP28-Recommandations-MIR.csv; then


### PR DESCRIPTION
This new version embbed
Use of cukinia ID
New cover page

The change is done only for Debian now.
We need to change the cukinia test on meta-seapath before doing the same for Yocto .