### PR TITLE
launch-yocto: restrict to rt and isolated vm

### DIFF
--- a/launch-yocto.sh
+++ b/launch-yocto.sh
@@ -135,6 +135,7 @@ deploy_vms() {
 
   cd ansible
   cqfd run ansible-playbook \
+  --limit "guest0"
   playbooks/ci_vms_standalone_ptp.yaml
   echo "test VMs deployed successfully"
 }


### PR DESCRIPTION
For the moment, we're concentrating on the development and testing of an rt and isolated vm, and we'll be moving on to a non-rt and non-isolated vm at a later date.