### PR TITLE
launch-yocto: add sv_timestamp_logger sources fetch

### DIFF
--- a/launch-yocto.sh
+++ b/launch-yocto.sh
@@ -32,6 +32,9 @@ fi
 if [ -z "${SEAPATH_SSH_BASE_REPO}" ] ; then
     SEAPATH_SSH_BASE_REPO="git@github.com:seapath"
 fi
+if [ -z "${SV_TIMESTAMP_LOGGER_SOURCES}" ] ; then
+    SV_TIMESTAMP_LOGGER_SOURCES="/etc/seapath-ci/sv_timestamp_logger"
+fi
 if [ -z "${INVENTORY_VM}" ] ; then
   INVENTORY_VM=inventories_private/ci_vms.yml
 fi
@@ -180,7 +183,7 @@ test_latency() {
   CQFD_EXTRA_RUN_ARGS="${CQFD_EXTRA_RUN_ARGS} -e ANSIBLE_INVENTORY=${ANSIBLE_INVENTORY}"
 
   # Build sv timestamp logger
-  cd sv_timestamp_logger
+  cd ${SV_TIMESTAMP_LOGGER_SOURCES}
   docker build . --tag sv_timestamp_logger -f Dockerfile
   docker image save -o sv_timestamp_logger.tar sv_timestamp_logger
   mv sv_timestamp_logger.tar ../ansible/ci_latency_tests/build/


### PR DESCRIPTION
Add a way to retrieve sv_timestamp_logger sources, stored in the CI runner