### PR TITLE
generate_latency_report: start histogram plot at zero

### DIFF
--- a/latency-tests-analysis/scripts/generate_latency_report.py
+++ b/latency-tests-analysis/scripts/generate_latency_report.py
@@ -43,7 +43,7 @@ def compute_average(latencies):
 
 def save_latency_histogram(latencies, vm, output):
     # Plot latency histograms
-    plt.hist(latencies, bins=20, alpha=0.7)
+    plt.hist(latencies, bins=20, alpha=0.7, range=(0, np.max(latencies)))
 
     # Add titles and legends
     plt.xlabel("Latency (us)")


### PR DESCRIPTION
Modification of the script to generate a histogram in particular, forcing plot startup to zero to enable more effective comparison of the different plots.