### PR TITLE
openlab: change report generation method

### DIFF
--- a/latency-tests-analysis/scripts/generate_latency_report.py
+++ b/latency-tests-analysis/scripts/generate_latency_report.py
@@ -52,18 +52,17 @@ def save_latency_histogram(latencies, vm, output):
     return filename
 
 def generate_adoc(output):
-    with open(f"{output}/notes.adoc", "w", encoding="utf-8") as adoc_file:
+    with open(f"{output}/latency_tests.adoc", "w", encoding="utf-8") as adoc_file:
         vm_result_files = glob.glob(str(output) + "/ts_guest*.txt")
         vm_names = [file.split("ts_")[1].split(".txt")[0]
                     for file in vm_result_files]
 
-        adoc_file.write("== Latency tests\n")
         vm_line = textwrap.dedent(
                 """
-                === VM {_vm_}
+                ===== VM {_vm_}
                 {{set:cellbgcolor!}}
                 |===
-                |Number of stream |Minimum latency |Maximum latency |Average latency
+                |Number of IEC61850 Sampled Value |Minimum latency |Maximum latency |Average latency
                 |{_stream_} |{_minlat_} us |{_maxlat_} us |{_avglat_} us
                 |===
                 image::latency_histogram_{_vm_}.png[]

--- a/launch-yocto.sh
+++ b/launch-yocto.sh
@@ -217,7 +217,7 @@ test_latency() {
   cqfd run python3 ci_latency_tests/results/generate_latency_report.py -o "${WORK_DIR}/ansible/ci_latency_tests/results"
 
   # Move report and images to the test report directory
-  cp "${WORK_DIR}/ansible/ci_latency_tests/results/notes.adoc" "${WORK_DIR}/ci/openlab/include/"
+  cp "${WORK_DIR}/ansible/ci_latency_tests/results/latency_tests.adoc" "${WORK_DIR}/ci/openlab/include/"
   for img in "${WORK_DIR}/ansible/ci_latency_tests/results/latency_histogram_guest*.png"; do
 	mv $img "${WORK_DIR}/ci/openlab/doc/"
   done

--- a/openlab/.cqfd/docker/Dockerfile
+++ b/openlab/.cqfd/docker/Dockerfile
@@ -1,0 +1,55 @@
+# Copyright (C) 2023 Savoir-faire Linux, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+FROM ubuntu:22.04
+
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN set -x \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
+        asciidoc \
+        black \
+        fd-find \
+        make \
+        openjdk-8-jre-headless \
+        pylint \
+        python3 \
+        python3-pip \
+        python3-sphinx \
+        ruby \
+        ruby-asciidoctor-pdf \
+        unzip \
+        wget \
+    && rm -rf /var/lib/apt/lists/
+
+RUN pip install junitparser==3.1.0
+
+ARG sonar_version=4.7.0.2747
+ARG sonar_repo=https://binaries.sonarsource.com/Distribution/sonar-scanner-cli
+RUN set -x \
+    && wget -O /tmp/sonar-scanner.zip \
+    "${sonar_repo}/sonar-scanner-cli-${sonar_version}.zip" \
+    && cd /opt \
+    && unzip /tmp/sonar-scanner.zip \
+    && rm -f sonar-scanner.zip
+RUN ln -s "/opt/sonar-scanner-${sonar_version}" /opt/sonar-scanner
+RUN echo 'sonar.host.url=http://j1.sfl.team:9000/' \
+    > /opt/sonar-scanner/conf/sonar-scanner.properties
+COPY python-sonar.sh /usr/bin/python-sonar.sh
+COPY detect_sonar_errors.py /usr/bin/detect_sonar_errors.py
+
+# Install cukinia to compile examples
+ADD https://raw.githubusercontent.com/savoirfairelinux/cukinia/master/cukinia /usr/bin/cukinia
+RUN chmod +xr /usr/bin/cukinia

--- a/openlab/.cqfd/docker/detect_sonar_errors.py
+++ b/openlab/.cqfd/docker/detect_sonar_errors.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+import json
+import sys
+
+with open(".scannerwork/sonar-report.json", "r") as fd:
+    raw = fd.read()
+
+sonar_result = json.loads(raw)
+
+nb_issues = 0
+
+if "issues" in sonar_result:
+    for issue in sonar_result["issues"]:
+        if issue["status"] == "OPEN" and issue["severity"] in (
+            "BLOCKER",
+            "CRITICAL",
+            "MAJOR",
+            "MINOR",
+        ):
+            nb_issues += 1
+
+if nb_issues > 0:
+    sys.exit(1)

--- a/openlab/.cqfd/docker/python-sonar.sh
+++ b/openlab/.cqfd/docker/python-sonar.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -e
+pylint --exit-zero $(fdfind -e py --exclude conf.py) \
+    >pylint-report.txt
+/opt/sonar-scanner/bin/sonar-scanner
+
+detect_sonar_errors.py

--- a/openlab/.cqfdrc
+++ b/openlab/.cqfdrc
@@ -1,0 +1,17 @@
+[project]
+org='sfl'
+name='test-report-pdf'
+
+[build]
+command=' \
+    cukinia -f junitxml -o examples/simple/results.xml examples/simple/cukinia.conf || true \
+    && ./compile.py -i examples/simple -C SFL -p simple_example \
+    && mv test-report.pdf simple-example.pdf \
+    && cukinia -f junitxml -o examples/complex/results.xml examples/complex/cukinia.conf || true \
+    && ./compile.py -i examples/complex -m -c examples/complex/matrix.csv -C SFL -p complex_example \
+    && mv test-report.pdf complex-example.pdf \
+'
+flavors='sonarqube'
+
+[sonarqube]
+command='/usr/bin/python-sonar.sh'

--- a/openlab/extended-pdf-converter.rb
+++ b/openlab/extended-pdf-converter.rb
@@ -1,0 +1,15 @@
+require 'asciidoctor-pdf' unless defined? ::Asciidoctor::Pdf
+
+module AsciidoctorPdfExtensions
+
+  def layout_title_page doc
+    super
+    theme_font :footer, level: 2 do
+        move_cursor_to page_margin_bottom
+        title_footer = apply_subs_discretely doc, @theme.footer_title_center_content, subs: [:attributes]
+        text title_footer, align: :center
+    end
+
+  end
+end
+Asciidoctor::Pdf::Converter.prepend AsciidoctorPdfExtensions

--- a/openlab/report.py
+++ b/openlab/report.py
@@ -1,0 +1,306 @@
+#! /usr/bin/python3
+
+import os
+import sys
+import glob
+from junitparser.junitparser import TestCase, JUnitXml, Properties
+import textwrap
+import argparse
+import csv
+
+GREEN_COLOR = "#90EE90"
+RED_COLOR = "#F08080"
+ORANGE_COLOR = "#ee6644"
+
+class CukiniaTest(TestCase):
+    '''
+    Custom class to get property value in TestCase
+    '''
+    def get_property_value(self, name):
+        '''
+        Gets a property from a testcase.
+        '''
+        props = self.child(Properties)
+        if props is None:
+            return None
+        for prop in props:
+            if prop.name == name:
+                return prop.value
+        return None
+
+def die(error_string):
+    print("ERROR : ", error_string)
+    sys.exit(1)
+
+# Cukinia test generation
+def check_for_id(suite):
+    '''
+    Check in the first test if there is an id. If yes return True otherwise
+    return False
+    '''
+    for test in suite:
+        if(CukiniaTest.fromelem(test).get_property_value("cukinia.id")):
+            return True
+        else:
+            return False
+
+def write_table_header(suite, adoc_file, has_test_id):
+
+    table_header = textwrap.dedent(
+        """
+        ===== Tests {_suitename_} {_machinepart_}
+        [options="header",cols="{_colsize_}",frame=all, grid=all]
+        |===
+        {_testid_}|Tests |Results
+        """
+    )
+
+    # Weird tricks to get the classname of the first test of the suite
+    # This classname is used as machine name.
+    machine_name = next(iter(suite)).classname
+    if args.add_machine_name:
+        machine_part = "for {}".format(machine_name)
+    else:
+        machine_part = ""
+
+    if has_test_id:
+        adoc_file.write(
+            table_header.format(
+                _suitename_=suite.name,
+                _machinepart_=machine_part,
+                _colsize_="2,6,1",
+                _testid_="|Test ID",
+            )
+        )
+    else:
+        adoc_file.write(
+            table_header.format(
+                _suitename_=suite.name,
+                _machinepart_=machine_part,
+                _colsize_="8,1",
+                _testid_="",
+            )
+        )
+
+
+def write_table_line(test, adoc_file, has_test_id):
+
+    table_line_test_id = textwrap.dedent(
+        """
+        |{_testid_}
+        {{set:cellbgcolor!}}
+        """
+    )
+
+    table_line = textwrap.dedent(
+        """
+        |{_testname_}
+        {{set:cellbgcolor!}}
+        |{_result_}
+        {{set:cellbgcolor:{_color_}}}
+        """
+    )
+
+    if has_test_id:
+        adoc_file.write(table_line_test_id.format(
+            _testid_=test.get_property_value("cukinia.id")))
+
+    if test.is_passed:
+        adoc_file.write(
+            table_line.format(
+                _testname_=test.name.replace('|', '|'),
+                _result_="PASS",
+                _color_=GREEN_COLOR,
+            )
+        )
+    else:
+        adoc_file.write(
+            table_line.format(
+                _testname_=test.name.replace('|', '|'),
+                _result_="FAIL",
+                _color_=RED_COLOR
+            )
+        )
+
+
+def write_table_footer(suite, adoc_file):
+    table_footer = textwrap.dedent(
+        """
+        |===
+        * number of tests: {_nbtests_}
+        * number of failures: {_nbfailures_}
+
+        """
+    )
+    adoc_file.write(
+        table_footer.format(_nbtests_=suite.tests, _nbfailures_=suite.failures)
+    )
+
+def add_compliance_matrix(matrix, xml_files):
+    if not os.path.exists(matrix):
+        die("Matrix file {} doesn't exists".format(matrix))
+    if not os.path.isfile(matrix):
+        die("Matrix file {} is not a file".format(matrix))
+    matrix_header = textwrap.dedent(
+        """
+            ===== Matrix {_matrixname_}
+            [options="header",cols="6,2,1",frame=all, grid=all]
+            |===
+            |Requirement |Test id |Status
+        """
+        )
+    with open(f"{args.include_dir}/test-{os.path.basename(matrix)}.adoc", "w", encoding="utf-8") as adoc_file:
+        adoc_file.write(matrix_header.format(_matrixname_=matrix))
+        with open(matrix, "r", encoding="utf-8") as matrix_file:
+            requirements = list(sorted(csv.reader(matrix_file)))
+            # requirements is a list, each item of the list has the form
+            # ["requirement name", test_ID]
+            write_matrix_tests(requirements, xml_files, adoc_file)
+            matrix_footer = textwrap.dedent(
+                """
+                |===
+                """
+            )
+            adoc_file.write(matrix_footer)
+
+
+def write_matrix_tests(requirements, xml_files, adoc_file):
+    matrix_line_req = textwrap.dedent(
+        """
+        .{_nbtests_}+|{_req_}
+        {{set:cellbgcolor!}}
+        """
+    )
+    matrix_line_test = textwrap.dedent(
+        """
+        |{_id_}
+        {{set:cellbgcolor!}}
+        |{_status_}
+        {{set:cellbgcolor:{_color_}}}
+        """
+    )
+    current_requirement = ""
+    for req, test_id in requirements:
+        # This code section uses the span rows feature of asciidoc
+        # https://docs.asciidoctor.org/asciidoc/latest/tables/span-cells/
+        if req != current_requirement:
+            current_requirement = req
+            nb_tests = sum([current_requirement == r[0] for r in requirements])
+            # nb_tests control the number of lines the requirement cell will
+            # be spanned. This number should be equal to the number of times
+            # the same requirement appears
+            adoc_file.write(
+                matrix_line_req.format(
+                    _nbtests_=nb_tests,
+                    _req_=req,
+                )
+            )
+        present, passed = check_test(test_id, xml_files)
+        if not present:
+            adoc_file.write(
+                matrix_line_test.format(
+                    _id_=test_id,
+                    _status_="ABSENT",
+                    _color_=ORANGE_COLOR,
+                )
+            )
+            die(f"ERROR : Test id {test_id} is not present")
+        elif passed:
+            adoc_file.write(
+                matrix_line_test.format(
+                    _id_=test_id,
+                    _status_="PASS",
+                    _color_=GREEN_COLOR,
+                )
+            )
+        else:
+            adoc_file.write(
+                matrix_line_test.format(
+                    _id_=test_id,
+                    _status_="FAIL",
+                    _color_=RED_COLOR,
+                )
+            )
+
+# This function read all the xml and look for all tests that matches a given ID.
+# It return present=True if the ID is found at least once
+# It return passed=False if at least one test is failed.
+def check_test(test_id, xml_files):
+
+    present = False
+    passed = True
+
+    for xml in xml_files:
+        for suite in xml:
+            for test in suite:
+                current_id = CukiniaTest.fromelem(test).get_property_value(
+                    "cukinia.id"
+                )
+                if current_id == test_id:
+                    present = True
+                    if not test.is_passed:
+                        passed = False
+    return present, passed
+
+def generate_adoc(file):
+    with open(f"{args.include_dir}/test-{os.path.basename(file)}.adoc", "w", encoding="utf-8") as adoc_file:
+        xml_file = JUnitXml.fromfile(file)
+        for suite in xml_file:
+            has_test_id = check_for_id(suite)
+            write_table_header(suite, adoc_file, has_test_id)
+            for test in suite:
+                write_table_line(CukiniaTest.fromelem(test), adoc_file,
+                                 has_test_id)
+            write_table_footer(suite, adoc_file)
+            if args.compliance_matrix:
+                if not has_test_id:
+                    die(
+                    "Can't include compliance matrix, test id feature is not enabled"
+                    )
+
+# Report generation
+def open_test_files(directory):
+    if not os.path.isdir(directory):
+        die("Directory {} does not exists".format(directory))
+    files = glob.glob(os.path.join(directory, "*.xml"))
+    if not files:
+        die("No test file found in {}".format(directory))
+    xml_files = []
+    for f in files:
+        xml_files.append(JUnitXml.fromfile(f))
+        generate_adoc(f)
+    return xml_files
+
+def parse_arguments():
+    parser= argparse.ArgumentParser()
+    parser.add_argument(
+        "-i",
+        "--include_dir",
+        help="""source directory to use for xml files and additionnal
+        adoc files.""",
+    )
+    parser.add_argument(
+        "-c",
+        "--compliance_matrix",
+        action="append",
+        help="""add the compliance matrix specified in the file.
+        Can be used multiple times for multiple matrices to add.""",
+    )
+    parser.add_argument(
+        "-m",
+        "--add_machine_name",
+        const=True,
+        default=False,
+        help="""Add the name of the machine in the title of each tables.
+        This machine name should be given in the test suite
+        using the classname feature of cukinia.""",
+        action="store_const",
+    )
+    return parser.parse_args()
+
+if __name__ == '__main__':
+    args = parse_arguments()
+    xml_files = open_test_files(args.include_dir)
+    if args.compliance_matrix:
+        for matrix in args.compliance_matrix:
+            add_compliance_matrix(matrix, xml_files)

--- a/openlab/test-report.adoc
+++ b/openlab/test-report.adoc
@@ -94,6 +94,12 @@ include::include/system_info.adoc[]
 ==== System Capabilities and Hardening
 include::include/test-cukinia_yoctoCI.xml.adoc[]
 
+<<< 
+==== ANSSI-BP28 Compliance
+include::include/test-ANSSI-BP28-M-Recommendations.csv.adoc[]
+include::include/test-ANSSI-BP28-MI-Recommendations.csv.adoc[]
+include::include/test-ANSSI-BP28-MIE-Recommendations.csv.adoc[]
+
 <<<
 ==== Virtual Machine Deployment
 include::include/test-cukinia_guest0.xml.adoc[]

--- a/openlab/test-report.adoc
+++ b/openlab/test-report.adoc
@@ -19,14 +19,13 @@
 
 = Test report {project}
 :toc:
+:toclevels: 4
 :icons:
 :iconsdir: ./doc/icons/
 :sectnumlevels: 1
 :revdate:
 :author: Savoir-faire Linux
 :email: contact@savoirfairelinux.com
-
-:toc:
 
 == List of supported equipment
 [.center]
@@ -81,18 +80,22 @@
 * Perform SV IEC61850 packet network latency tests
 * Compute latency between publisher and userspace of VM 
 
-image::setup_lat.png[network latency test setup, 490, align=center]
+image::images/setup_lat.png[network latency test setup, 490, align=center]
 
+== SFL
 === SEAPATH CI
 ==== Setup Information
 include::include/system_info.adoc[]
 
-==== System Capabilities
-==== Hardening and ANSSI-BP28 Compliance
-==== Virtual Machine Deployment
-==== Network Latency Testing
+==== System Capabilities and Hardening
+include::include/test-cukinia_yoctoCI.xml.adoc[]
 
-include::test-report-content.adoc[]
+==== Virtual Machine Deployment
+include::include/test-cukinia_guest0.xml.adoc[]
+include::include/test-cukinia_guest1.xml.adoc[]
+
+==== Network Latency Testing
+include::include/notes.adoc[]
 
 == About this documentation
 

--- a/openlab/test-report.adoc
+++ b/openlab/test-report.adoc
@@ -27,12 +27,14 @@
 :author: Savoir-faire Linux
 :email: contact@savoirfairelinux.com
 
+<<<
 == List of supported equipment
 [.center]
 
 * SFL
 ** <<SEAPATH CI>>
 
+<<<
 == Testing Setup
 === Setup Information
 * Retrieve system information:
@@ -82,21 +84,26 @@
 
 image::images/setup_lat.png[network latency test setup, 490, align=center]
 
+<<<
 == SFL
 === SEAPATH CI
 ==== Setup Information
 include::include/system_info.adoc[]
 
+<<<
 ==== System Capabilities and Hardening
 include::include/test-cukinia_yoctoCI.xml.adoc[]
 
+<<<
 ==== Virtual Machine Deployment
 include::include/test-cukinia_guest0.xml.adoc[]
 include::include/test-cukinia_guest1.xml.adoc[]
 
+<<<
 ==== IEC61850 Sampled Value Latency Testing
 include::include/latency_tests.adoc[]
 
+<<<
 == About this documentation
 
 This documentation uses the AsciiDoc documentation generator. It is a convenient

--- a/openlab/test-report.adoc
+++ b/openlab/test-report.adoc
@@ -76,7 +76,7 @@
   ** Real-time (cyclic test)
   ** SV IEC61850 packet network latency tests
 
-=== Network Latency Testing
+=== IEC61850 Sampled Value Latency Testing
 * Perform SV IEC61850 packet network latency tests
 * Compute latency between publisher and userspace of VM 
 
@@ -94,8 +94,8 @@ include::include/test-cukinia_yoctoCI.xml.adoc[]
 include::include/test-cukinia_guest0.xml.adoc[]
 include::include/test-cukinia_guest1.xml.adoc[]
 
-==== Network Latency Testing
-include::include/notes.adoc[]
+==== IEC61850 Sampled Value Latency Testing
+include::include/latency_tests.adoc[]
 
 == About this documentation
 

--- a/openlab/themes/theme.yml
+++ b/openlab/themes/theme.yml
@@ -1,0 +1,61 @@
+# Copyright (C) 2023 Savoir-faire Linux, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+extends: default
+title_page:
+  background_color: #56b0c9
+  align: center
+  logo:
+    image: image:sfl.png[width=30%, align=center]
+  title:
+    top: 30%
+    font_style: bold
+    font_color: #ffffff
+    line_height: 0.9
+    text-transform: uppercase
+  authors:
+    margin-top: 40
+    content:
+      with_email: |
+          Receiver: {author}
+          Contact: <{email}>
+    font-color: #181818
+code:
+  font_color: #333333
+  font_style: normal
+  font_size: 10
+  background_color: #f6f6f6
+  border_color: #56b0c9
+  border_radius: 2
+base:
+  font_color: #000000
+table:
+  align: center
+  border_color: #000000
+  font-size: 8
+  head:
+    font-size: 10
+    background-color: #56b0c9
+footer:
+  height: 0.75in
+  verso: &shared_footer
+    center:
+      content: Copyright © {year} Savoir-faire Linux
+  recto: *shared_footer
+  title:
+      center:
+        content: |
+            Copyright © {year} Savoir-faire Linux
+            The registered trademark Linux® is used pursuant to a sublicense from LMI, the exclusive license of Linus Torvalds, owner of the mark on a world-wide basis.


### PR DESCRIPTION
We no longer use test-report-pdf for the moment,
we generate an adoc file for each type of cukinia
test and add them all to the final report.