### PR TITLE
generate_latency_report: add latency limit

### DIFF
--- a/latency-tests-analysis/scripts/generate_latency_report.py
+++ b/latency-tests-analysis/scripts/generate_latency_report.py
@@ -5,10 +5,13 @@ import matplotlib.pyplot as plt
 import textwrap
 import numpy as np
 
+GREEN_COLOR = "#90EE90"
+RED_COLOR = "#F08080"
+
 def compute_latency(vm,output):
     vm_path = f"{output}/ts_{vm}.txt"
     pub_path = f"{output}/ts_sv_publisher.txt"
-    latencies = np.array([]) 
+    latencies = np.array([])
     with open(vm_path, buffering=10**4) as vm_file, open(pub_path, buffering=10**4) as pub_file:
         vm_lines = vm_file.readlines()
         pub_lines = pub_file.readlines()
@@ -34,7 +37,7 @@ def compute_max(latencies):
 def compute_average(latencies):
     return np.round(np.mean(latencies)) if latencies.size > 0 else None
 
-def save_latency_histogram(latencies, vm, output):
+def save_latency_histogram(latencies, vm, output, limit=None):
     # Plot latency histograms
     plt.hist(latencies, bins=20, alpha=0.7, range=(0, np.max(latencies)))
 
@@ -43,46 +46,82 @@ def save_latency_histogram(latencies, vm, output):
     plt.ylabel("Frequency")
     plt.title(f"Latency Histogram for {vm}")
 
+    # Add a red vertical line for the limit
+    if limit is not None:
+        plt.axvline(x=limit, color='red', linestyle='dashed', linewidth=2, label=f'Limit ({limit} us)')
+        plt.legend()
+
     # Save the plot
     if not os.path.exists(output):
         os.makedirs(output)
     filename = os.path.realpath(f"{output}/latency_histogram_{vm}.png")
     plt.savefig(filename, format='png')
+    plt.close()
     print(f"Histogram saved as 'latency_histogram_{vm}.png'.")
     return filename
 
-def generate_adoc(output):
+def generate_adoc(output, limit):
     with open(f"{output}/latency_tests.adoc", "w", encoding="utf-8") as adoc_file:
         vm_result_files = glob.glob(str(output) + "/ts_guest*.txt")
         vm_names = [file.split("ts_")[1].split(".txt")[0]
                     for file in vm_result_files]
 
         vm_line = textwrap.dedent(
-                """
-                ===== VM {_vm_}
-                {{set:cellbgcolor!}}
-                |===
-                |Number of IEC61850 Sampled Value |Minimum latency |Maximum latency |Average latency
-                |{_stream_} |{_minlat_} us |{_maxlat_} us |{_avglat_} us
-                |===
-                image::latency_histogram_{_vm_}.png[]
-                """
+            """
+            ===== VM {_vm_}
+            {{set:cellbgcolor!}}
+            |===
+            |Number of IEC61850 Sampled Value |Minimum latency |Maximum latency |Average latency
+            |{_stream_} |{_minlat_} us |{_maxlat_} us |{_avglat_} us
+            |===
+            image::latency_histogram_{_vm_}.png[]
+            """
         )
+        pass_line = textwrap.dedent(
+            """
+            [cols="1,1",frame=all, grid=all]
+            |===
+            |Max latency < {_limit_} us
+            {{set:cellbgcolor!}}
+            |{_result_}
+            {{set:cellbgcolor:{_color_}}}
+            |===
+            """
+        )
+
         for vm in vm_names:
             latencies = compute_latency(vm, output)
-            filename = save_latency_histogram(latencies,vm,output)
+            filename = save_latency_histogram(latencies,vm,output, limit)
+            maxlat= compute_max(latencies)
             adoc_file.write(
                     vm_line.format(
                         _vm_=vm,
                         _stream_= get_stream_count(output),
                         _minlat_= compute_min(latencies),
-                        _maxlat_= compute_max(latencies),
+                        _maxlat_= maxlat,
                         _avglat_= compute_average(latencies),
                     )
             )
+            if maxlat < limit:
+                adoc_file.write(
+                    pass_line.format(
+                        _limit_=limit,
+                        _result_="PASS",
+                        _color_=GREEN_COLOR,
+                    )
+                )
+            else:
+                adoc_file.write(
+                    pass_line.format(
+                        _limit_=limit,
+                        _result_="FAILED",
+                        _color_=RED_COLOR,
+                    )
+                )
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Generate Latency tests report in AsciiDoc format.")
     parser.add_argument("--output", "-o", default="../results/", type=str, help="Output directory for the generated files.")
+    parser.add_argument("--limit", "-l", default="1000", type=int, help="Latency limit to unvalidate the test." )
     args = parser.parse_args()
-    generate_adoc(args.output)
+    generate_adoc(args.output, args.limit)

--- a/launch-yocto.sh
+++ b/launch-yocto.sh
@@ -112,8 +112,8 @@ launch_system_tests() {
   playbooks/ci_all_machines_tests.yaml
   echo "System tests launched successfully"
 
-  # Generate cyclictest report parts 
-  CPU_CORES=$(cat "${WORK_DIR}/ansible/system_info.adoc" | grep "physical CPUs" |  grep -o "[0-9]\+")    
+  # Generate cyclictest report parts
+  CPU_CORES=$(cat "${WORK_DIR}/ansible/system_info.adoc" | grep "physical CPUs" |  grep -o "[0-9]\+")
   cqfd run scripts/gen_cyclic_test.sh \
   -i "${WORK_DIR}/ansible/cyclictest_yoctoCI.txt" \
   -o "${WORK_DIR}/ansible/cyclictest_results_hyp.png" \
@@ -186,7 +186,7 @@ test_vms() {
   -o "${WORK_DIR}/ansible/cyclictest_results_vm.png" \
   -n 2
   mv "${WORK_DIR}"/ansible/cyclictest_results_vm.png "$IMAGE_DIR"
-    
+
   # Display test results
   if grep '<failure' "$INCLUDE_DIR"/*.xml | grep -q -v '00080'; then
     echo "Test fails, See test report in the section 'Upload test report'"
@@ -233,6 +233,14 @@ test_latency() {
   # Launch script
   cp "${WORK_DIR}/ci/latency-tests-analysis/scripts/generate_latency_report.py" ci_latency_tests/results/
   cqfd run python3 ci_latency_tests/results/generate_latency_report.py -o "${WORK_DIR}/ansible/ci_latency_tests/results"
+
+  # Check if latency tests passed
+  if grep -q "FAILED" "${WORK_DIR}/ansible/ci_latency_tests/results/latency_tests.adoc"; then
+    echo "Test fails, See test report in the section 'Upload test report'"
+    exit 1
+  else
+    echo "All tests pass"
+  fi
 
   # Move report and images to the test report directory
   cp "${WORK_DIR}/ansible/ci_latency_tests/results/latency_tests.adoc" "${WORK_DIR}/ci/openlab/include/"


### PR DESCRIPTION
Add a limit value, invalidating the CI if exceeded, in latency tests.