### PR TITLE
launch.sh: stop using network playbook on VMs

### DIFF
--- a/launch.sh
+++ b/launch.sh
@@ -172,8 +172,9 @@ launch_vm_tests() {
   cqfd run ansible-playbook \
   --key-file "${PRIVATE_KEYFILE_PATH}" \
   --limit VMs \
-  playbooks/cluster_setup_debian.yaml \
-  playbooks/cluster_setup_hardened_debian.yaml
+  playbooks/seapath_setup_prerequisdebian.yaml \
+  playbooks/seapath_setup_hardened_debian.yaml \
+  playbooks/ci_prepare_VMs.yaml
 
   cqfd run ansible-playbook \
   --key-file "${PRIVATE_KEYFILE_PATH}" \


### PR DESCRIPTION
As discussed with Florent in
https://github.com/seapath/ansible/pull/585#issuecomment-2306561089 we should stop using standard playbooks on VMs.
This commit start to do the job by calling directly the prerequisdebian on the VM, thus avoiding the network playbook to be applied. Some required setup is done in a new playbook called ci_prepare_VMs.

Also, cluster_setup_hardened_debian is now renamed to seapath_setup_hardened_debian