### PR TITLE
launch-yocto: add openlab initialization

### DIFF
--- a/launch-yocto.sh
+++ b/launch-yocto.sh
@@ -92,6 +92,9 @@ initialization() {
   cqfd init
   cqfd -b prepare
   echo "Sources prepared succesfully"
+
+  # Prepare openlab
+  cqfd -C ../ci/openlab init
 }
 
 # Launch SEAPATH configuration and hardening


### PR DESCRIPTION
The `cqfd init` was missing for the openlab configuration.