### PR TITLE
launch: merge CI and ansible-lint

### DIFF
--- a/launch-yocto.sh
+++ b/launch-yocto.sh
@@ -106,6 +106,12 @@ configure_seapath() {
   echo "SEAPATH set up succesfully"
 }
 
+# Launch ansible-lint
+ansible_lint() {
+  cd ansible
+  cqfd -b ansible-lint
+}
+
 # Prepare and launch cukinia test
 # Send the result of the tests as return code
 launch_system_tests() {
@@ -343,6 +349,10 @@ case "$1" in
     ;;
   conf)
     configure_seapath
+    exit 0
+    ;;
+  lint)
+    ansible_lint
     exit 0
     ;;
   system)

--- a/launch.sh
+++ b/launch.sh
@@ -108,6 +108,12 @@ initialization() {
   echo "Sources prepared succesfully"
 }
 
+# Launch ansible-lint
+ansible_lint() {
+  cd ansible
+  cqfd -b ansible-lint
+}
+
 # Launch Debian configuration and hardening
 configure_debian() {
   cd ansible
@@ -285,6 +291,10 @@ generate_report() {
 case "$1" in
   init)
     initialization
+    exit 0
+    ;;
+  lint)
+    ansible_lint
     exit 0
     ;;
   conf)


### PR DESCRIPTION
To avoid having to run the whole CI pipeline if we have an Ansible error, run ansible-lint command before running any Ansible playbook.