### PR TITLE
openlab: remove Testing Setup chapter

### DIFF
--- a/openlab/test-report.adoc
+++ b/openlab/test-report.adoc
@@ -42,18 +42,7 @@ The purpose of this document is to certify the correct operation of the open sou
 A series of tests has been carried out on a range of equipment from several vendors, in order to certify SEAPATH on them. Certified in virtualization functions, security, real-time functionality and network latency of IEC61850 Sampled Values.
 
 <<<
-== Testing Setup
-=== Setup Information
 
-=== System Capabilities
-
-
-
-=== IEC61850 Sampled Value Latency Testing
-
-image::images/setup_lat.png[network latency test setup, 490, align=center]
-
-<<<
 == Welotec
 === RSAPC Mk2
 ==== Setup Information


### PR DESCRIPTION
The content of testing setup was removed but not the chapter.