### PR TITLE
launch-yocto: add Aaeon I.MX8 board to the CI

### DIFF
--- a/launch-yocto.sh
+++ b/launch-yocto.sh
@@ -289,14 +289,16 @@ generate_report() {
 
   # Generate Yocto CI tests part
   cqfd -q init
-  if ! CQFD_EXTRA_RUN_ARGS="" cqfd -q run ./report.py \
-          -m -i include \
-          -x include/cukinia_yoctoCI.xml \
-          -c include/ANSSI-BP28-M-Recommendations.csv \
-          -c include/ANSSI-BP28-MI-Recommendations.csv \
-          -c include/ANSSI-BP28-MIE-Recommendations.csv; then
-            die "cqfd error"
-  fi
+  for cukinia_xml in include/cukinia_yoctoCI*.xml; do
+    if ! CQFD_EXTRA_RUN_ARGS="" cqfd -q run ./report.py \
+            -m -i include \
+            -x "$cukinia_xml" \
+            -c include/ANSSI-BP28-M-Recommendations.csv \
+            -c include/ANSSI-BP28-MI-Recommendations.csv \
+            -c include/ANSSI-BP28-MIE-Recommendations.csv; then
+      die "cqfd error"
+    fi
+  done
 
   # Generate VM tests part
   if ! CQFD_EXTRA_RUN_ARGS="" cqfd -q run ./report.py \

--- a/launch-yocto.sh
+++ b/launch-yocto.sh
@@ -143,6 +143,7 @@ deploy_vms() {
 
   cd ansible
   cqfd run ansible-playbook \
+  --limit '!yoctoCI-aaeon' \
   playbooks/ci_vms_standalone_ptp.yaml
   echo "test VMs deployed successfully"
 }

--- a/launch-yocto.sh
+++ b/launch-yocto.sh
@@ -39,7 +39,7 @@ if [ -z "${INVENTORY_PUBLISHER}" ]; then
   INVENTORY_PUBLISHER=inventories_private/ci_publisher.yml
 fi
 if [ -z "${ANSIBLE_INVENTORY}" ] ; then
-  ANSIBLE_INVENTORY="inventories_private/ci_yocto_standalone.yaml"
+  ANSIBLE_INVENTORY="inventories_private/ci_yocto_standalone.yaml,inventories_private/ci_yocto_standalone_aaeon.yaml"
 fi
 CQFD_EXTRA_RUN_ARGS="-e ANSIBLE_INVENTORY=${ANSIBLE_INVENTORY}"
 export CQFD_EXTRA_RUN_ARGS

--- a/openlab/report.py
+++ b/openlab/report.py
@@ -263,7 +263,6 @@ def write_matrix_tests(requirements, machine_name, xml_files, adoc_file):
                 )
             )
             print(f"Test id {test_id} is not present for {machine_name}")
-            return_code = 1
         elif passed:
             adoc_file.write(
                 matrix_line_test.format(

--- a/openlab/test-report.adoc
+++ b/openlab/test-report.adoc
@@ -32,9 +32,13 @@
 == List of supported equipment
 [.center]
 
+=== Virtualization
 * Welotec
 ** <<RSAPC Mk2>>
 
+=== Containerization
+* Aaeon
+** <<ARM I.MX8P-2G>>
 <<<
 == Introduction
 The purpose of this document is to certify the correct operation of the open source real-time operating system for virtualizing IEDs: SEAPATH, a project under the governance of the Linux Foundation Energy.
@@ -46,7 +50,7 @@ A series of tests has been carried out on a range of equipment from several vend
 == Welotec
 === RSAPC Mk2
 ==== Setup Information
-include::include/system_info.adoc[]
+include::include/system_info_yoctoCI.adoc[]
 
 <<<
 ==== System Capabilities and Hardening
@@ -124,6 +128,39 @@ include::include/cyclictest_vm.adoc[opts=optional]
 * Test duration: @@TEST_DURATION@@
 
 include::include/latency_tests.adoc[]
+
+<<<
+== Aaeon
+=== ARM I.MX8P-2G
+==== Setup Information
+include::include/system_info_yoctoCI-aaeon.adoc[]
+
+<<<
+==== System Capabilities and Hardening
+
+include::include/test-cukinia_yoctoCI-aaeon.xml.adoc[]
+
+<<<
+==== ANSSI-BP28 Compliance
+
+include::include/test-yoctoCI-aaeon-ANSSI-BP28-M-Recommendations.csv.adoc[]
+include::include/test-yoctoCI-aaeon-ANSSI-BP28-MI-Recommendations.csv.adoc[]
+include::include/test-yoctoCI-aaeon-ANSSI-BP28-MIE-Recommendations.csv.adoc[]
+
+For more information, please refer to https://lf-energy.atlassian.net/wiki/x/O4TlAQ[LF Energy wiki page].
+
+<<<
+===== Container
+====== CONTAINER_NAME
+==== IEC61850 Sampled Value Latency Testing
+* Purpose of the test
+  ** Perform SV IEC61850 packet network latency tests
+  ** Compute latency between publisher and container NIC.
+
+* Number of sent IEC61850 Sampled Values streams: 8
+* Test duration: @@TEST_DURATION@@
+
+// include::include/latency_tests.adoc[]
 
 <<<
 == About this documentation


### PR DESCRIPTION
These commits allows to run the CI on a second machine .

As this is an arm machine and the current version of SEAPATH arm does not support RT, cyclictests will not be addressed in this PR. Adding the cyclictests would require to refactor the script to avoid a lot a code duplication.