### PR TITLE
launch-yocto.sh: fix report generation

### DIFF
--- a/launch-yocto.sh
+++ b/launch-yocto.sh
@@ -166,7 +166,7 @@ test_vms() {
   # Generate test report part
   INCLUDE_DIR=${WORK_DIR}/ci/openlab/include
   mkdir -p "$INCLUDE_DIR"
-  mv "${WORK_DIR}"/ansible/cukinia_*.xml "$INCLUDE_DIR"
+  mv "${WORK_DIR}"/ansible/cukinia_guest*.xml "$INCLUDE_DIR"
 
   # Generate cyclictest report part
   cd ../ci/openlab


### PR DESCRIPTION
The refactor made by [1] reoved the generation of the Cukinia tests from launch_system_tests() to generate_report(). Since the function test_vms() was also moving all the Cukinia tests an error was generated during the report generation.

[1]: https://g1.sfl.team/c/rte/votp/meta-seapath/+/39295