### PR TITLE
launch-yocto: add latency tests for the board Aaeon

### DIFF
--- a/openlab/test-report.adoc
+++ b/openlab/test-report.adoc
@@ -128,7 +128,7 @@ include::include/cyclictest_vm.adoc[opts=optional]
 * Number of sent IEC61850 Sampled Values streams: 8
 * Test duration: @@TEST_DURATION@@
 
-include::include/latency_tests.adoc[]
+include::include/latency_tests_yoctoCI.adoc[]
 
 <<<
 == Aaeon
@@ -161,7 +161,10 @@ For more information, please refer to https://lf-energy.atlassian.net/wiki/x/O4T
 * Number of sent IEC61850 Sampled Values streams: 8
 * Test duration: @@TEST_DURATION@@
 
-// include::include/latency_tests.adoc[]
+The latency tests for the Aaeon board are purely informative.
+As the Linux kernel used is not RT, high latencies are expected.
+
+include::include/latency_tests_yoctoCI-aaeon.adoc[]
 
 <<<
 == About this documentation


### PR DESCRIPTION
A new docker image is build to use sv_timestamp_logger on arm, to run the latency tests and compile the results for the Aaeon board.

These results are added to the CI report.