### PR TITLE
report.py: change orange color used on reports

### DIFF
--- a/openlab/report.py
+++ b/openlab/report.py
@@ -10,7 +10,7 @@ import csv
 
 GREEN_COLOR = "#90EE90"
 RED_COLOR = "#F08080"
-ORANGE_COLOR = "#ee6644"
+ORANGE_COLOR = "#F0B880"
 
 
 class CukiniaTest(TestCase):


### PR DESCRIPTION
The old orange color could be confused with the color used for failed tests. This was due to the hue of the color used: 0° which correspond to red.