### PR TITLE
launch-yocto.sh: move latency test result copy

### DIFF
--- a/launch-yocto.sh
+++ b/launch-yocto.sh
@@ -253,6 +253,11 @@ test_latency() {
       --display_max_latency \
       -o "${WORK_DIR}/ansible/ci_latency_tests_yoctoCI-aaeon"
 
+  # Move report and images to the test report directory
+  cp ${WORK_DIR}/ansible/ci_latency_tests_yoctoCI/results/latency_tests.adoc "${WORK_DIR}/ci/openlab/include/latency_tests_yoctoCI.adoc"
+  cp ${WORK_DIR}/ansible/ci_latency_tests_yoctoCI-aaeon/results/latency_tests.adoc "${WORK_DIR}/ci/openlab/include/latency_tests_yoctoCI-aaeon.adoc"
+  mv ${WORK_DIR}/ansible/ci_latency_tests_*/results/histogram*.png ${WORK_DIR}/ci/openlab/doc/
+
   # Check if latency tests passed
   if grep -q "FAILED" ${WORK_DIR}/ansible/ci_latency_tests_*/results/latency_tests.adoc; then
     echo "Test fails, See test report in the section 'Upload test report'"
@@ -260,11 +265,6 @@ test_latency() {
   else
     echo "All tests pass"
   fi
-
-  # Move report and images to the test report directory
-  cp ${WORK_DIR}/ansible/ci_latency_tests_yoctoCI/results/latency_tests.adoc "${WORK_DIR}/ci/openlab/include/latency_tests_yoctoCI.adoc"
-  cp ${WORK_DIR}/ansible/ci_latency_tests_yoctoCI-aaeon/results/latency_tests.adoc "${WORK_DIR}/ci/openlab/include/latency_tests_yoctoCI-aaeon.adoc"
-  mv ${WORK_DIR}/ansible/ci_latency_tests_*/results/histogram*.png ${WORK_DIR}/ci/openlab/doc/
 }
 
 # Generate the test report and upload it


### PR DESCRIPTION
If the latency test fails, the check will automatically stop the latency function.
In that case, the copy commands at the end of the function will not be executed, and thus not displayed in the test report.

This commit changes the location of the copy commands, so the histogram are visible on the report, even if the latency tests fail.