### PR TITLE
launch-yocto.sh: fix sv_timestamp_path following cqfd update

### DIFF
--- a/launch-yocto.sh
+++ b/launch-yocto.sh
@@ -253,7 +253,10 @@ test_latency() {
   echo "Latency tests launched succesfully"
 
   # Analyse SV timestamps with sv_timestamp_analysis
-  sv_timestamp_path="${WORK_DIR}/ansible/ci_latency_tests/sv-timestamp-analysis"
+
+  # Use relative path from ansible directory as cqfd currently doesn't support
+  # absolute paths for -d option
+  sv_timestamp_path="ci_latency_tests/sv-timestamp-analysis"
 
   git clone -q "https://${SEAPATH_BASE_REPO}/sv-timestamp-analysis" ${sv_timestamp_path}
   cqfd -d "${sv_timestamp_path}/.cqfd" -f "${sv_timestamp_path}/.cqfdrc" init


### PR DESCRIPTION
On recent versions of cqfd, the -d option doesn't work with absolute paths. As cqfd was recently updated on the SEAPATH CI Yocto runner to 5.6.0+, set sv_timestamp_path as a relative path.