### PR TITLE
launch-{centos, debian, oraclelinux}.sh: update hardening playbook name

### DIFF
--- a/launch-centos.sh
+++ b/launch-centos.sh
@@ -164,7 +164,7 @@ launch_vm_tests() {
   --key-file "${PRIVATE_KEYFILE_PATH}" \
   --limit VMs \
   playbooks/seapath_setup_prerequisdebian.yaml \
-  playbooks/seapath_setup_hardened_debian.yaml \
+  playbooks/seapath_setup_hardening.yaml \
   playbooks/ci_prepare_VMs.yaml
 
   cqfd run ansible-playbook \

--- a/launch-debian.sh
+++ b/launch-debian.sh
@@ -165,7 +165,7 @@ launch_vm_tests() {
   --key-file "${PRIVATE_KEYFILE_PATH}" \
   --limit VMs \
   playbooks/seapath_setup_prerequisdebian.yaml \
-  playbooks/seapath_setup_hardened_debian.yaml \
+  playbooks/seapath_setup_hardening.yaml \
   playbooks/ci_prepare_VMs.yaml
 
   cqfd run ansible-playbook \
@@ -184,7 +184,7 @@ launch_vm_tests() {
   --key-file "${PRIVATE_KEYFILE_PATH}" \
   --limit VMs \
   playbooks/seapath_setup_prerequisdebian.yaml \
-  playbooks/seapath_setup_hardened_debian.yaml \
+  playbooks/seapath_setup_hardening.yaml \
   playbooks/ci_prepare_VMs.yaml
 
   cqfd run ansible-playbook \

--- a/launch-oraclelinux.sh
+++ b/launch-oraclelinux.sh
@@ -164,7 +164,7 @@ launch_vm_tests() {
   --key-file "${PRIVATE_KEYFILE_PATH}" \
   --limit VMs \
   playbooks/seapath_setup_prerequisdebian.yaml \
-  playbooks/seapath_setup_hardened_debian.yaml \
+  playbooks/seapath_setup_hardening.yaml \
   playbooks/ci_prepare_VMs.yaml
 
   cqfd run ansible-playbook \
@@ -183,7 +183,7 @@ launch_vm_tests() {
   --key-file "${PRIVATE_KEYFILE_PATH}" \
   --limit VMs \
   playbooks/seapath_setup_prerequisdebian.yaml \
-  playbooks/seapath_setup_hardened_debian.yaml \
+  playbooks/seapath_setup_hardening.yaml \
   playbooks/ci_prepare_VMs.yaml
 
   cqfd run ansible-playbook \


### PR DESCRIPTION
Hardening playbooks' name recently changed to be more coherent with other playbook names.

[1]: https://github.com/seapath/ansible/pull/947

Related to https://github.com/seapath/ansible/pull/947