### PR TITLE
launch-debian.sh: update test role name

### DIFF
--- a/launch-debian.sh
+++ b/launch-debian.sh
@@ -125,7 +125,7 @@ launch_system_tests() {
   INCLUDE_DIR=${WORK_DIR}/ci/test-report-pdf/include
   mkdir "$INCLUDE_DIR"
   mv ${WORK_DIR}/ansible/cukinia_*.xml $INCLUDE_DIR # Test files
-  cp ${WORK_DIR}/ansible/roles/debian_tests/cukinia-tests/*.csv $INCLUDE_DIR # Compliance matrix
+  cp ${WORK_DIR}/ansible/roles/deploy_cukinia_tests/cukinia-tests/*.csv $INCLUDE_DIR # Compliance matrix
 
   # Check for kernel backtrace error. This is a random error so it must not
   # stop the CI but just display a warning


### PR DESCRIPTION
In the SEAPATH Ansible repository, the debian_tests role has been renamed deploy_cukinia_tests as it won't be used only for SEAPATH Debian.

Related to https://github.com/seapath/ansible/pull/955